### PR TITLE
updated registration links

### DIFF
--- a/src/components/components/Navbar.js
+++ b/src/components/components/Navbar.js
@@ -35,7 +35,7 @@ class Navbar extends React.Component {
                                 </li>
                                 <li className='nav-item'>
                                     <h6>
-                                        <a href='https://ucsd.zoom.us/j/99955400276' target="_blank" rel="noreferrer" className='nav-link'>Zoom</a>
+                                        <a href='https://ucsd.zoom.us/w/93617051961' target="_blank" rel="noreferrer" className='nav-link'>Zoom</a>
                                     </h6>
                                 </li>
                             </ul>

--- a/src/components/pages/Register.js
+++ b/src/components/pages/Register.js
@@ -23,7 +23,7 @@ class Register extends React.Component {
                             <h3>How to Register</h3>
                             <p>Register for the conference by filling in the Zoom form.</p>
                             <button className="gradient-button">
-                                <a className="" href="https://ucsd.zoom.us/meeting/register/tJ0kcuysrjsoHdI4R2riooSFJI0qz5s46bOk" target="_blank" rel="noopener noreferrer">Register Here</a>
+                                <a className="" href="http://tinyurl.com/cogsconference2023" target="_blank" rel="noopener noreferrer">Register Here</a>
                             </button>
                         </div> 
                         <div className="col-sm-6 pb-5">


### PR DESCRIPTION
changes:
* nav bar zoom tab
* registration link on registration page
* background is not changed but if we should, then probably change to speakers page background would be easier
- [ ]  if so, then we should wait for https://github.com/CSSA-UCSD/conference2023/pull/20 to be merged and add background to this branch

test:
* all links are updated and work